### PR TITLE
Add interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ With this plugin you can define shortcodes for arbitrary content to be rendered 
 markdown. The shortcodes take the form of _self-closing_ HTML5 tags:
 
 ```html
-<custom first second="string" third=3.7>
+<custom first second="string" third=3.7 fourth={myvar} >
 ```
 
 You cannot write closing tags and consequently no inner content. Attributes are passed
@@ -42,8 +42,14 @@ var shortcodes = {
     ...]
 }
 
+var options = {
+    interpolator: function(expr, env) { ... } // resolves interpolated expression
+                                              // default interpolator simply looks up 
+                                              // expr in env
+}
+
 var md = require('markdown-it')({html: true})
-        .use(require('markdown-it-shortcode-tag'), );
+        .use(require('markdown-it-shortcode-tag'), shortcodes);
 
 
 md.render(content, env);
@@ -56,7 +62,7 @@ md.render(content, env);
     [HTML5 rules][3] for attribute syntax apply with one __caveat__: _unquoted_ attribute values
     are converted to numbers using `parseFloat()`.  
     Attributes without values are represented as boolean `true`, quoted attribute values as strings.
-  - __env__ - the enviroment variable passed to markdown-it in a `md.render(content, env)` call.
+  - __env__ - the enviroment variable passed to markdown-it in a `md.render(content, env)` call, and to the `options.interpolator(expr, env)` method.
 - __inline__ - optional, if true the shortcode is always rendered inline (surrounded by
   `<p></p>` tags), even if stands on its own separated line
 
@@ -86,7 +92,9 @@ var shortcodes = {
 var md = require('markdown-it')({html: true})
         .use(require('markdown-it-shortcode-tag'), shortcodes);
 
-console.log(md.render('<media method="img" src="assets/picture.jpg" width=400 side="left">'));
+console.log(md.render('<media method="img" src={picture} width=400 side="left">', {
+    picture: "assets/picture.jpg"
+}));
 ```
 
 Output:
@@ -95,7 +103,25 @@ Output:
 <img src="assets/picture.jpg" alt="" width="400" style="float:left">
 ```
 
-### Render an enviroment variable
+### Render an environment variable using interpolation
+
+```js
+var shortcodes = {
+    image: {
+        render: function (attrs) {
+            return '<img src="'+attrs.src+'" >';
+        }
+    }
+}
+
+var md = require('markdown-it')({html: true})
+        .use(require('markdown-it-shortcode-tag'), shortcodes);
+
+console.log(md.render('<image src={url} >', { url: "/images/img.png" }));
+// => <img src="/images/img.png" >
+```
+
+### Render an enviroment variable using shortcodes
 
 ```js
 var shortcodes = {

--- a/index.js
+++ b/index.js
@@ -84,7 +84,6 @@ module.exports = function shortcode_plugin (md, shortcodes, options) {
         while (attr = reAttrs.exec(content)) {
             if (attr[4]) { //interpolated
                 let expr = attr[4].slice(1, -1).trim();
-                let interpolatedResult = interpolator(expr, env);
                 parameters[attr[1]] = interpolator(expr, env);
             } else if (attr[3]) { //quoted
                 parameters[attr[1]] = attr[3].slice(1, -1);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 "use strict";
 
-module.exports = function shortcode_plugin (md, shortcodes) {
+module.exports = function shortcode_plugin (md, shortcodes, options) {
+    options = options || {};
+    const interpolator = options.interpolator || function (expr, env) { return env[expr]; };
     const defaultRuleIndex = md.block.ruler.__find__('html_block');
     if (defaultRuleIndex < 0 || !shortcodes) return;
 
@@ -11,12 +13,17 @@ module.exports = function shortcode_plugin (md, shortcodes) {
             throw new Error('missing render function for shortcode tag: ' + tag);
         }
     }
-
+    
     const reName = '([a-zA-Z_:][a-zA-Z0-9:._-]*)';
     const reNumber = '(-?(?:\\d*\\.\\d+|\\d+)(?:[eE]-?\\d+)?)';
     const reString = '(\'[^\']*\'|"[^"]*")';
-
-    const reAttrs = new RegExp('\\s+' + reName + '(?:\\s*=\\s*(?:' + reNumber + '|' + reString + '))?','g');
+    const reExpr = '(\\{[^}]*\\})';
+  
+    const reAttrs = new RegExp(
+        '\\s+' + reName + 
+        '(?:\\s*=\\s*(?:' + reNumber + '|' + reString + '|' + reExpr + '))?',
+        'g'
+    );
 
     const reTag = /^<(\w+)/;
 
@@ -72,10 +79,14 @@ module.exports = function shortcode_plugin (md, shortcodes) {
 
     function render (tokens, idx, options, env, self) {
         const content = tokens[idx].content;
-
+        
         let parameters = {}, attr;
         while (attr = reAttrs.exec(content)) {
-            if (attr[3]) { //quoted
+            if (attr[4]) { //interpolated
+                let expr = attr[4].slice(1, -1).trim();
+                let interpolatedResult = interpolator(expr, env);
+                parameters[attr[1]] = interpolator(expr, env);
+            } else if (attr[3]) { //quoted
                 parameters[attr[1]] = attr[3].slice(1, -1);
             } else if (attr[2]) { //number
                 parameters[attr[1]] = parseFloat(attr[2]);

--- a/tests/fixtures/block.md
+++ b/tests/fixtures/block.md
@@ -1,6 +1,6 @@
 # Hello Shortcode
 
-<standard first second="string" third= 'other' fourth =3.7>
+<standard first second="string" third= 'other' fourth =3.7 fifth={local} >
 
 <unknown attr>
 

--- a/tests/shortcodeSpec.js
+++ b/tests/shortcodeSpec.js
@@ -38,12 +38,15 @@ describe("plugin usage", function () {
         });
 
         it("understands attributes", function () {
-            var result = md.render(source);
+            var result = md.render(source, { 
+                local: "test" 
+            });
             expect(result).toContain('<pre>');
             expect(result).toContain('first: true (boolean)');
             expect(result).toContain('second: string (string)');
             expect(result).toContain('third: other (string)');
             expect(result).toContain('fourth: 3.7 (number)');
+            expect(result).toContain('fifth: test (string)');
         });
 
         it("passes enviroment", function () {
@@ -57,6 +60,25 @@ describe("plugin usage", function () {
         it("ignores closing tags", function () {
             var result = md.render(source);
             expect(result).toContain('</standard>');
+        });
+    });
+
+    describe("options", function () {
+        var source = fs.readFileSync('tests/fixtures/block.md', {encoding: 'utf8'});
+            
+        beforeEach(function() {
+            var interpolator = function (expr, env) { 
+                return "interpolated("+ env[expr] + ")"; 
+            }
+            md.use(shortcode, {standard: standard}, { interpolator });
+        });
+
+        it("should use the interpolator option to process {expression} values", function () {
+            var result = md.render(source, {
+                local: "test"
+            });
+            
+            expect(result).toContain("fifth: interpolated(test) (string)");
         });
     });
 


### PR DESCRIPTION
Adds simple interpolation capability:
```js
var shortcodes = {
    image: {
        render: function (attrs) {
            return '<img src="'+attrs.src+'" >';
        }
    }
}

var md = require('markdown-it')({html: true})
        .use(require('markdown-it-shortcode-tag'), shortcodes);

console.log(md.render('<image src={url} >', { url: "/images/img.png" }));
// => <img src="/images/img.png" >
```

This capability is useful in a situation where a website user creates markdown and may wish to provide either string or an environment variable. The interpolation capability solves this problem.

One limitation is that spaces are not allowed inside the interpolation braces. (This is due to Markdown not recognizing tags containing such syntax as html - which results in < and > characters being encoded.)